### PR TITLE
스프린트 미션 3 - 최희락

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:title" content="판다마켓" />
+    <meta property="og:url" content="https://elaborate-swan-f535ed.netlify.app/" />
+    <meta property="og:image" content="https://elaborate-swan-f535ed.netlify.app/image/botoomimg.png" />
+    <meta property="og:type" content="website" />
+    <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="판다마켓" />
+    <meta name="twitter:description" content="일상의 모든 물건을 거래해보세요" />
+    <meta name="twitter:image" content="https://elaborate-swan-f535ed.netlify.app/image/botoomimg.png" />
     <title>판다마켓</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/Pretendard.css" />
     <link rel="stylesheet" href="style.css">
@@ -25,7 +34,9 @@
         <div class="home">
             <div class="home-box">
                 <div class="home-text-box">
-                    <span id="home-text">일상의 모든 물건을<br>거래해 보세요</span>
+                    <h2>
+                        <span id="home-text">일상의 모든 물건을 <br>거래해 보세요</span>
+                    </h2>
                     <a href="/item" id="go-look-button">구경하러 가기</a>
                 </div>
                 <div class="home-image">
@@ -33,7 +44,6 @@
                 </div>
             </div>
         </div>
-
         <div class="main-content">
             <div class="content">
                 <div class="content-box">
@@ -44,10 +54,10 @@
                         <div class="content-header">
                             Hot item
                         </div>
-                        <div class="content-title">
+                        <h2 class="content-title">
                             인기 상품을<br>
                             확인해 보세요
-                        </div>
+                        </h2>
                         <div class="content-info">
                             가장 HOT한 중고거래 물품을<br>
                             판다 마켓에서 확인해 보세요
@@ -61,10 +71,10 @@
                         <div class="content-header">
                             Search
                         </div>
-                        <div class="content-title">
+                        <h2 class="content-title">
                             구매를 원하는<br>
                             상품을 검색하세요
-                        </div>
+                        </h2>
                         <div class="content-info">
                             구매하고 싶은 물품은 검색해서<br>
                             쉽게 찾아보세요
@@ -80,13 +90,14 @@
                     <div class="content-image register-image">
                         <img src="image/trust.png" alt="상품 등록">
                     </div>
-                    <div class="content-text-box">
-                        <div class="content-header">
-                            Register
-                        </div>
-                        <div class="content-title">
-                            판매를 원하는<br>
-                            상품을 등록하세요
+                    <div class="content-text-box-text">
+                        <div class="content-text-box">
+                            <div class="content-header">
+                                Register
+                            </div>
+                            <h2 class="content-title">
+                                판매를 원하는<br>
+                                상품을 등록하세요
                         </div>
                         <div class="content-info">
                             어떤 물건이든 판매하고 싶은 상품을<br>
@@ -95,6 +106,7 @@
                     </div>
                 </div>
             </div>
+        </div>
         </div>
     </main>
 
@@ -115,13 +127,10 @@
                 <div class="footer-codeit">
                     ©codeit - 2024
                 </div>
-                <div class="footer-ppf">
-                    <a href="/privacy">
-                        Privacy Policy
-                    </a>
-                    <a href="/faq">
-                        FAQ
-                    </a>
+                <div class="footer-top">
+                    <div class="footer-ppf"> <a href="/privacy">Privacy Policy</a>
+                        <a href="/faq">FAQ</a>
+                    </div>
                 </div>
                 <div class="footer-sns">
                     <a class="sns-box" href="https://www.facebook.com/" target="_blank"><img

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <header>
         <div class="header-box">
             <a href="/" id="header-logo">
-                <img src="image/pandlogo.png" alt="판다마켓로고">
+                <img src="image/panda_face.png" alt="판다마켓로고"> <span class="header-tit">판다마켓</span>
             </a>
             <a href="/login" class="login-button">
                 로그인
@@ -57,7 +57,7 @@
             </div>
             <div class="content">
                 <div class="content-box">
-                    <div id="second-content" class="content-text-box">
+                    <div class="content-text-box text-right">
                         <div class="content-header">
                             Search
                         </div>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
+
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +14,7 @@
     <header>
         <div class="header-box">
             <a href="/" id="header-logo">
-            <img src="image/pandlogo.png" alt="판다마켓로고">
+                <img src="image/pandlogo.png" alt="판다마켓로고">
             </a>
             <a href="/login" class="login-button">
                 로그인
@@ -45,12 +46,12 @@
                         </div>
                         <div class="content-title">
                             인기 상품을<br>
-                            확인해 보세요    
+                            확인해 보세요
                         </div>
                         <div class="content-info">
                             가장 HOT한 중고거래 물품을<br>
                             판다 마켓에서 확인해 보세요
-                        </div>                        
+                        </div>
                     </div>
                 </div>
             </div>
@@ -62,12 +63,12 @@
                         </div>
                         <div class="content-title">
                             구매를 원하는<br>
-                            상품을 검색하세요    
+                            상품을 검색하세요
                         </div>
                         <div class="content-info">
                             구매하고 싶은 물품은 검색해서<br>
                             쉽게 찾아보세요
-                        </div>                        
+                        </div>
                     </div>
                     <div class="content-image search-image">
                         <img src="image/search.png" alt="상품 검색">
@@ -85,12 +86,12 @@
                         </div>
                         <div class="content-title">
                             판매를 원하는<br>
-                            상품을 등록하세요    
+                            상품을 등록하세요
                         </div>
                         <div class="content-info">
                             어떤 물건이든 판매하고 싶은 상품을<br>
                             쉽게 등록하세요
-                        </div>                        
+                        </div>
                     </div>
                 </div>
             </div>
@@ -102,11 +103,11 @@
             <div class="footer-main-box">
                 <div class="footer-text">
                     믿을 수 있는<br>
-                    판다마켓 중고 거래                    
+                    판다마켓 중고 거래
                 </div>
                 <div class="footer-image">
                     <img src="image/botoomimg.png" alt="푸터 이미지">
-                </div>            
+                </div>
             </div>
         </div>
         <div class="footer-bottom">
@@ -123,17 +124,22 @@
                     </a>
                 </div>
                 <div class="footer-sns">
-                    <a class="sns-box" href="https://www.facebook.com/" target="_blank"><img src="image/sns_icon/facebookicon.png" alt="Facebook">
+                    <a class="sns-box" href="https://www.facebook.com/" target="_blank"><img
+                            src="image/sns_icon/facebookicon.png" alt="Facebook">
                     </a>
-                    <a class="sns-box" href="https://www.twitter.com/" target="_blank"><img src="image/sns_icon/twitericon.png" alt="facebook">
+                    <a class="sns-box" href="https://www.twitter.com/" target="_blank"><img
+                            src="image/sns_icon/twitericon.png" alt="facebook">
                     </a>
-                    <a class="sns-box" href="https://www.youtube.com/" target="_blank"><img src="image/sns_icon/youtubeicon.png" alt="youtube">
+                    <a class="sns-box" href="https://www.youtube.com/" target="_blank"><img
+                            src="image/sns_icon/youtubeicon.png" alt="youtube">
                     </a>
-                    <a class="sns-box" href="https://www.instagram.com/" target="_blank"><img src="image/sns_icon/instaicon.png" alt="instagram">
+                    <a class="sns-box" href="https://www.instagram.com/" target="_blank"><img
+                            src="image/sns_icon/instaicon.png" alt="instagram">
                     </a>
                 </div>
             </div>
         </div>
     </footer>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta property="og:title" content="판다마켓" />
-    <meta property="og:url" content="https://elaborate-swan-f535ed.netlify.app/" />
-    <meta property="og:image" content="https://elaborate-swan-f535ed.netlify.app/image/botoomimg.png" />
+    <meta property="og:url" content="https://capable-concha-4462b3.netlify.app/" />
+    <meta property="og:image" content="https://capable-concha-4462b3.netlify.app/image/botoomimg.png" />
     <meta property="og:type" content="website" />
     <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="판다마켓" />
     <meta name="twitter:description" content="일상의 모든 물건을 거래해보세요" />
-    <meta name="twitter:image" content="https://elaborate-swan-f535ed.netlify.app/image/botoomimg.png" />
+    <meta name="twitter:image" content="https://capable-concha-4462b3.netlify.app/image/botoomimg.png" />
     <title>판다마켓</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/Pretendard.css" />
     <link rel="stylesheet" href="style.css">

--- a/login.css
+++ b/login.css
@@ -1,13 +1,28 @@
-.wrap{
+/*body {
+    display: flex;
+    justify-content: center;
+    /* 가로 중앙 정렬 }*/
+
+.wrap {
+    display: flex;
+    max-width: 1920px;
+    /* 최대 폭 */
+    margin: 0 auto;
+    /* 가운데 정렬 */
+    padding: 231px 20px;
+    /* 좌우 패딩은 고정값 대신 최소 여백 */
+}
+
+/*.wrap{
     display: flex;
     width: 1920px;
     padding: 231px 640px;
     justify-content: center;
     align-items: center;
     background: #FCFCFC;
-}
+}*/
 
-.formWrap{
+.formWrap {
     display: flex;
     width: 640px;
     flex-direction: column;
@@ -20,31 +35,31 @@ a,
 a:visited,
 a:hover,
 a:active {
-  text-decoration: none;  
-  color: inherit;          
+    text-decoration: none;
+    color: inherit;
 }
 
 .input-common {
-  width: 640px;
-  height: 56px;
-  padding: 16px 24px;
-  border-radius: 12px;
-  background: #F3F4F6;
-  border: 2px solid rgba(49, 130, 246, 0.00);
-  box-sizing: border-box;
-  font-size: 16px;
+    width: 640px;
+    height: 56px;
+    padding: 16px 24px;
+    border-radius: 12px;
+    background: #F3F4F6;
+    border: 2px solid rgba(49, 130, 246, 0.00);
+    box-sizing: border-box;
+    font-size: 16px;
 }
 
 
-.panda_logo{
+.panda_logo {
     display: flex;
     align-items: center;
-    flex-direction:row-reverse;
+    flex-direction: row-reverse;
     width: 396px;
     height: 132px;
 }
 
-.logo{
+.logo {
     color: var(--brand-blue, #3692FF);
     font-family: "ROKAF Sans";
     font-size: 66.344px;
@@ -56,7 +71,7 @@ a:active {
 
 
 
-.formWrap.panda_logo.blind{
+.formWrap.panda_logo.blind {
     color: var(--brand-blue, #3692FF);
     font-family: "ROKAF Sans";
     font-size: 66.344px;
@@ -66,7 +81,7 @@ a:active {
 
 }
 
-.authForm.socialBtn-main.guideBtn{
+.authForm.socialBtn-main.guideBtn {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -75,14 +90,14 @@ a:active {
 }
 
 
-.panda_face{
+.panda_face {
     width: 103.529px;
     height: 103.88px;
     flex-shrink: 0;
     margin: auto;
 }
 
-.btn_lg{
+.btn_lg {
     display: flex;
     width: 640px;
     height: 56px;
@@ -99,10 +114,11 @@ a:active {
     font-size: 20px;
     font-style: normal;
     font-weight: 600;
-    line-height: 32px; /* 160% */
+    line-height: 32px;
+    /* 160% */
 }
 
-.btnTxt{
+.btnTxt {
     color: var(--Primary-100, #3692FF);
     font-family: Pretendard;
     font-size: 14px;
@@ -117,7 +133,7 @@ a:active {
     text-underline-position: from-font;
 }
 
-.socialBtn-main{
+.socialBtn-main {
     display: flex;
     height: 74px;
     flex-direction: column;
@@ -131,7 +147,7 @@ a:active {
     background: #E6F2FF;
 }
 
-.socialBtn{
+.socialBtn {
     display: flex;
     width: 594px;
     justify-content: space-between;
@@ -139,7 +155,7 @@ a:active {
 }
 
 
-.socialBtn-box-google img{
+.socialBtn-box-google img {
     display: flex;
     width: 22px;
     height: 22px;
@@ -148,7 +164,8 @@ a:active {
     flex-shrink: 0;
     margin: 10px 10px 10px 10px;
 }
-.socialBtn-box-google{
+
+.socialBtn-box-google {
     width: 42px;
     height: 42px;
     flex-shrink: 0;
@@ -157,23 +174,23 @@ a:active {
 }
 
 
-.socialBtn-box-kakao img{
+.socialBtn-box-kakao img {
     width: 26px;
     height: 24px;
     flex-shrink: 0;
     margin: 10px 8px 8px 8px;
 }
 
-.socialBtn-box-kakao{
+.socialBtn-box-kakao {
     width: 42px;
     height: 42px;
     flex-shrink: 0;
     background-color: #F5E14B;
     border-radius: 100%;
-    
+
 }
 
-#user-email{
+#user-email {
     display: flex;
     width: 640px;
     height: 56px;
@@ -190,7 +207,7 @@ a:active {
     border: 2px solid rgba(49, 130, 246, 0.00);
 }
 
-#user-pw{
+#user-pw {
     display: flex;
     width: 640px;
     height: 56px;
@@ -202,22 +219,23 @@ a:active {
     background: var(--Cool-Gray-100, #F3F4F6);
 }
 
-#user-pw.login_eyes{
+#user-pw.login_eyes {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
     align-self: stretch;
 }
 
-.tit{
+.tit {
     text-align: center;
     color: var(--Secondary-800, #1F2937);
-/* pretendard/lg-16px-medium */
+    /* pretendard/lg-16px-medium */
     font-family: Pretendard;
     font-size: 16px;
     font-style: normal;
     font-weight: 500;
-    line-height: 26px; /* 162.5% */
+    line-height: 26px;
+    /* 162.5% */
 }
 
 .ipt-email,
@@ -228,14 +246,14 @@ a:active {
     gap: 16px;
 }
 
-.authForm{
+.authForm {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 24px;
 }
 
-.btns{
+.btns {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -244,33 +262,33 @@ a:active {
 }
 
 .pw-box {
-  display: flex;
-  align-items: center;
-  width: 640px;
-  height: 56px;
-  padding: 0 16px;
-  border-radius: 12px;
-  background: #F3F4F6;
-  border: 1px solid #ccc;
-  box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    width: 640px;
+    height: 56px;
+    padding: 0 16px;
+    border-radius: 12px;
+    background: #F3F4F6;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
 }
 
 .input-common {
-  flex: 1; 
-  border: none;
-  background: transparent;
-  font-size: 16px;
-  height: 100%;
-  outline: none;
-  padding-left: 16px;
+    flex: 1;
+    border: none;
+    background: transparent;
+    font-size: 16px;
+    height: 100%;
+    outline: none;
+    padding-left: 16px;
 }
 
 .icon-wrapper {
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  display: flex; 
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
 }

--- a/login.css
+++ b/login.css
@@ -1,30 +1,15 @@
-/*body {
-    display: flex;
-    justify-content: center;
-    /* 가로 중앙 정렬 }*/
-
 .wrap {
+    min-height: 100vh;
+    align-items: center;
+    justify-content: center;
     display: flex;
     max-width: 1920px;
-    /* 최대 폭 */
     margin: 0 auto;
-    /* 가운데 정렬 */
     padding: 231px 20px;
-    /* 좌우 패딩은 고정값 대신 최소 여백 */
 }
-
-/*.wrap{
-    display: flex;
-    width: 1920px;
-    padding: 231px 640px;
-    justify-content: center;
-    align-items: center;
-    background: #FCFCFC;
-}*/
 
 .formWrap {
     display: flex;
-    width: 640px;
     flex-direction: column;
     align-items: center;
     gap: 40px;
@@ -40,6 +25,8 @@ a:active {
 }
 
 .input-common {
+    background: #F9FAFB;
+    border: none;
     width: 640px;
     height: 56px;
     padding: 16px 24px;
@@ -48,6 +35,8 @@ a:active {
     border: 2px solid rgba(49, 130, 246, 0.00);
     box-sizing: border-box;
     font-size: 16px;
+    font-size: 16px;
+    outline: none;
 }
 
 
@@ -99,7 +88,7 @@ a:active {
 
 .btn_lg {
     display: flex;
-    width: 640px;
+    width: 645px;
     height: 56px;
     padding: 16px 124px;
     justify-content: center;
@@ -109,13 +98,11 @@ a:active {
     background: var(--Primary-100, #3692FF);
     color: var(--Cool-Gray-100, #F3F4F6);
     text-align: center;
-    /* pretendard/xl-20px-semibold */
     font-family: Pretendard;
     font-size: 20px;
     font-style: normal;
     font-weight: 600;
     line-height: 32px;
-    /* 160% */
 }
 
 .btnTxt {
@@ -134,15 +121,15 @@ a:active {
 }
 
 .socialBtn-main {
+    background: #F3F8FF;
+    padding: 12px 23px;
+    height: auto;
     display: flex;
-    height: 74px;
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
-    padding: 16px 23px;
     gap: 10px;
     border-radius: 8px;
-    align-self: stretch;
     border: 2px solid rgba(49, 130, 246, 0.00);
     background: #E6F2FF;
 }
@@ -150,8 +137,9 @@ a:active {
 .socialBtn {
     display: flex;
     width: 594px;
-    justify-content: space-between;
+    gap: 16px;
     align-items: center;
+    justify-content: space-between
 }
 
 
@@ -200,10 +188,8 @@ a:active {
     gap: 10px;
     border-radius: 12px;
     background: var(--Cool-Gray-100, #F3F4F6);
-    height: 56px;
     flex-shrink: 0;
     align-self: stretch;
-    border-radius: 12px;
     border: 2px solid rgba(49, 130, 246, 0.00);
 }
 
@@ -211,7 +197,6 @@ a:active {
     display: flex;
     width: 640px;
     height: 56px;
-    padding: 16px 24px;
     flex-direction: column;
     align-items: flex-start;
     gap: 10px;
@@ -221,21 +206,21 @@ a:active {
 
 #user-pw.login_eyes {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 16px;
     align-items: flex-start;
     align-self: stretch;
 }
 
+
 .tit {
     text-align: center;
     color: var(--Secondary-800, #1F2937);
-    /* pretendard/lg-16px-medium */
     font-family: Pretendard;
     font-size: 16px;
     font-style: normal;
     font-weight: 500;
     line-height: 26px;
-    /* 162.5% */
 }
 
 .ipt-email,
@@ -261,28 +246,6 @@ a:active {
     gap: 16px;
 }
 
-.pw-box {
-    display: flex;
-    align-items: center;
-    width: 640px;
-    height: 56px;
-    padding: 0 16px;
-    border-radius: 12px;
-    background: #F3F4F6;
-    border: 1px solid #ccc;
-    box-sizing: border-box;
-}
-
-.input-common {
-    flex: 1;
-    border: none;
-    background: transparent;
-    font-size: 16px;
-    height: 100%;
-    outline: none;
-    padding-left: 16px;
-}
-
 .icon-wrapper {
     flex-shrink: 0;
     width: 24px;
@@ -291,4 +254,134 @@ a:active {
     justify-content: center;
     align-items: center;
     cursor: pointer;
+}
+
+.guideBtn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    align-self: stretch;
+}
+
+.pw-box {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 640px;
+    height: 56px;
+    border-radius: 12px;
+    background: #F3F4F6;
+}
+
+.toggle-pw {
+    position: absolute;
+    right: 20px;
+    background: none;
+    width: 36px;
+    height: 36px;
+    border: none;
+    cursor: pointer;
+    font-size: 18px;
+}
+
+.login_eyes {
+    position: absolute;
+    left: 6px;
+    bottom: 6px;
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+@media screen and (min-width: 375px) and (max-width: 767px) {
+    .wrap {
+        padding: 80px 16px 16px 16px;
+    }
+
+    .formWrap {
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+        gap: 24px;
+    }
+
+    .panda_logo {
+        width: 100%;
+        max-width: 300px;
+        height: auto;
+        gap: 16px;
+        justify-content: center;
+    }
+
+
+    .panda_face {
+        width: 60px;
+        height: 60px;
+        margin: 0;
+        /* 추가: auto 마진 제거 */
+    }
+
+
+    .logo {
+        font-size: 40px;
+    }
+
+    .input-common,
+    #user-email,
+    #user-pw {
+        width: 100%;
+        max-width: 400px;
+        box-sizing: border-box;
+    }
+
+    .pw-box {
+        width: 100%;
+        max-width: 400px;
+        box-sizing: border-box;
+    }
+
+    .btn_lg {
+        width: 100%;
+        max-width: 400px;
+        padding: 16px 20px;
+        font-size: 18px;
+    }
+
+    .socialBtn-main {
+        width: 100%;
+        max-width: 400px;
+        padding: 16px;
+        box-sizing: border-box;
+    }
+
+    .socialBtn {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .authForm {
+        width: 100%;
+    }
+
+    .area {
+        width: 100%;
+    }
+
+    .ipt-email,
+    .ipt-pw {
+        width: 100%;
+    }
+
+    .guideBtn {
+        text-align: center;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
 }

--- a/login.html
+++ b/login.html
@@ -20,26 +20,25 @@
                 <img class="panda_face" src="image/panda_face.png" alt="로그인-판다머리아이콘">
             </div>
             <form class="authForm">
-                <div class="ipt-email">
-                    <label for="user-email">
-                        이메일
-                    </label>
-                    <input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
-                </div>
-                <div class="ipt-pw">
-                    <label for="user-pw">
-                        비밀번호
-                    </label>
-                    <div class="pw-box">
-                        <input id="user-pw" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
-                        <div class="icon-wrapper">
-                            <button type="button" aria-label="비밀번호 보이기">
+                <div class="area">
+                    <div class="ipt-email">
+                        <label for="user-email">
+                            이메일
+                        </label>
+                        <input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
+                    </div>
+                    <div class="ipt-pw">
+                        <label for="user-pw">
+                            비밀번호
+                        </label>
+                        <div class="pw-box">
+                            <input id="user-pw" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
+                            <button type="button" class="toggle-pw" aria-label="비밀번호 표시 전환">
                                 <img class="login_eyes" src="image/btn_visibility_on_24px.png" alt="로그인 눈모양">
                             </button>
                         </div>
                     </div>
-                </div>
-                <button type="submit" class="btn_lg">로그인</button>
+                    <button type="submit" class="btn_lg">로그인</button>
             </form>
             <div class="socialBtn-main">
                 <div class="socialBtn">
@@ -59,7 +58,8 @@
                 <span class="tit">판다마켓이 처음이신가요?</span>
                 <a href="/signup" class="btnTxt">회원가입</a>
             </div>
-        </main>
+    </div>
+    </main>
     </div>
 </body>
 

--- a/login.html
+++ b/login.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,51 +10,57 @@
 </head>
 
 <body>
-	<div class="wrap">
-		<main class="formWrap">
+    <div class="wrap">
+        <main class="formWrap">
             <div class="panda_logo">
-			<span class="logo"><a href="/">
-                <span class="blind">
-                    판다마켓
-                </span></a></span>
-            <img class="panda_face" src="image/panda_face.png" alt="로그인-판다머리아이콘">
+                <span class="logo"><a href="/">
+                        <span class="blind">
+                            판다마켓
+                        </span></a></span>
+                <img class="panda_face" src="image/panda_face.png" alt="로그인-판다머리아이콘">
             </div>
             <form class="authForm">
-				<div class="ipt-email">
-					<label for="user-email">
+                <div class="ipt-email">
+                    <label for="user-email">
                         이메일
                     </label>
-					<input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
-				</div>
-				<div class="ipt-pw">
-					<label for="user-pw">
+                    <input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
+                </div>
+                <div class="ipt-pw">
+                    <label for="user-pw">
                         비밀번호
                     </label>
                     <div class="pw-box">
-					<input id="user-pw" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
-                    <div class="icon-wrapper">
-                    <img class="login_eyes" src="image/btn_visibility_on_24px.png" alt="로그인 눈모양">
-				</div>
+                        <input id="user-pw" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
+                        <div class="icon-wrapper">
+                            <button type="button" aria-label="비밀번호 보이기">
+                                <img class="login_eyes" src="image/btn_visibility_on_24px.png" alt="로그인 눈모양">
+                            </button>
+                        </div>
+                    </div>
                 </div>
-               </div> 
-				<button type="button" class="btn_lg">로그인</button>
-			</form>
-        <div class="socialBtn-main">
-			<div class="socialBtn">
-				<span class="tit">
-                    간편 로그인하기
-                </span>
-				<div class="btns">
-					<a class="socialBtn-box-google" href="https://www.google.com/" target="_blank" rel="noopener noreferrer" title="새창으로 열기"><img src="image/google_icon.png" alt="구글 로그인"></a>
-                    <a class="socialBtn-box-kakao"  href="https://www.kakaocorp.com/page/" target="_blank" rel="noopener noreferrer" title="새창으로 열기"><img src="image/kakao_icon.png" alt="카카오톡 로그인"></a>
-				</div>
-			</div>
-        </div>
-			<div class="guideBtn">
-				<span class="tit">판다마켓이 처음이신가요?</span>
-				<a href="/signup" class="btnTxt">회원가입</a>
-			</div>
-		</main>
-	</div>
+                <button type="submit" class="btn_lg">로그인</button>
+            </form>
+            <div class="socialBtn-main">
+                <div class="socialBtn">
+                    <span class="tit">
+                        간편 로그인하기
+                    </span>
+                    <div class="btns">
+                        <a class="socialBtn-box-google" href="https://www.google.com/" target="_blank"
+                            rel="noopener noreferrer" title="새창으로 열기"><img src="image/google_icon.png" alt="구글 로그인"></a>
+                        <a class="socialBtn-box-kakao" href="https://www.kakaocorp.com/page/" target="_blank"
+                            rel="noopener noreferrer" title="새창으로 열기"><img src="image/kakao_icon.png"
+                                alt="카카오톡 로그인"></a>
+                    </div>
+                </div>
+            </div>
+            <div class="guideBtn">
+                <span class="tit">판다마켓이 처음이신가요?</span>
+                <a href="/signup" class="btnTxt">회원가입</a>
+            </div>
+        </main>
+    </div>
 </body>
+
 </html>

--- a/signup.css
+++ b/signup.css
@@ -1,13 +1,14 @@
-.wrap{
-    display: flex;
-    width: 1920px;
-    padding: 231px 640px;
-    justify-content: center;
+.wrap {
+    min-height: 100vh;
     align-items: center;
-    background: #FCFCFC;
+    justify-content: center;
+    display: flex;
+    max-width: 1920px;
+    margin: 0 auto;
+    padding: 231px 20px;
 }
 
-.formWrap{
+.formWrap {
     display: flex;
     width: 640px;
     flex-direction: column;
@@ -20,31 +21,34 @@ a,
 a:visited,
 a:hover,
 a:active {
-  text-decoration: none;  
-  color: inherit;          
+    text-decoration: none;
+    color: inherit;
 }
 
 .input-common {
-  width: 640px;
-  height: 56px;
-  padding: 16px 24px;
-  border-radius: 12px;
-  background: #F3F4F6;
-  border: 2px solid rgba(49, 130, 246, 0.00);
-  box-sizing: border-box;
-  font-size: 16px;
+    background: #F9FAFB;
+    border: none;
+    width: 640px;
+    height: 56px;
+    padding: 16px 24px;
+    border-radius: 12px;
+    background: #F3F4F6;
+    border: 2px solid rgba(49, 130, 246, 0.00);
+    box-sizing: border-box;
+    font-size: 16px;
+    outline: none;
 }
 
 
-.panda_logo{
+.panda_logo {
     display: flex;
     align-items: center;
-    flex-direction:row-reverse;
+    flex-direction: row-reverse;
     width: 396px;
     height: 132px;
 }
 
-.logo{
+.logo {
     color: var(--brand-blue, #3692FF);
     font-family: "ROKAF Sans";
     font-size: 66.344px;
@@ -56,7 +60,7 @@ a:active {
 
 
 
-.formWrap.panda_logo.blind{
+.formWrap.panda_logo.blind {
     color: var(--brand-blue, #3692FF);
     font-family: "ROKAF Sans";
     font-size: 66.344px;
@@ -67,7 +71,7 @@ a:active {
 }
 
 .authForm,
-.socialBtn-main{
+.socialBtn-main {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -75,24 +79,23 @@ a:active {
     align-self: stretch;
 }
 
-.guideBtn{
+.guideBtn {
     display: flex;
     align-items: center;
-    gap: 4px
-;
+    gap: 4px;
 }
 
 
-.panda_face{
+.panda_face {
     width: 103.529px;
     height: 103.88px;
     flex-shrink: 0;
     margin: auto;
 }
 
-.btn_lg{
+.btn_lg {
     display: flex;
-    width: 640px;
+    width: 645px;
     height: 56px;
     padding: 16px 124px;
     justify-content: center;
@@ -102,15 +105,14 @@ a:active {
     background: var(--Primary-100, #3692FF);
     color: var(--Cool-Gray-100, #F3F4F6);
     text-align: center;
-    /* pretendard/xl-20px-semibold */
     font-family: Pretendard;
     font-size: 20px;
     font-style: normal;
     font-weight: 600;
-    line-height: 32px; /* 160% */
+    line-height: 32px;
 }
 
-.btnTxt{
+.btnTxt {
     color: var(--Primary-100, #3692FF);
     font-family: Pretendard;
     font-size: 14px;
@@ -125,13 +127,12 @@ a:active {
     text-underline-position: from-font;
 }
 
-.socialBtn-main{
+.socialBtn-main {
     display: flex;
-    height: 74px;
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
-    padding: 16px 23px;
+    padding: 16px;
     gap: 10px;
     border-radius: 8px;
     align-self: stretch;
@@ -139,15 +140,16 @@ a:active {
     background: #E6F2FF;
 }
 
-.socialBtn{
+.socialBtn {
     display: flex;
     width: 594px;
     justify-content: space-between;
+    gap: 16px;
     align-items: center;
 }
 
 
-.socialBtn-box-google img{
+.socialBtn-box-google img {
     display: flex;
     width: 22px;
     height: 22px;
@@ -156,7 +158,8 @@ a:active {
     flex-shrink: 0;
     margin: 10px 10px 10px 10px;
 }
-.socialBtn-box-google{
+
+.socialBtn-box-google {
     width: 42px;
     height: 42px;
     flex-shrink: 0;
@@ -165,23 +168,23 @@ a:active {
 }
 
 
-.socialBtn-box-kakao img{
+.socialBtn-box-kakao img {
     width: 26px;
     height: 24px;
     flex-shrink: 0;
     margin: 10px 8px 8px 8px;
 }
 
-.socialBtn-box-kakao{
+.socialBtn-box-kakao {
     width: 42px;
     height: 42px;
     flex-shrink: 0;
     background-color: #F5E14B;
     border-radius: 100%;
-    
+
 }
 
-#user-email{
+#user-email {
     display: flex;
     width: 640px;
     height: 56px;
@@ -198,7 +201,7 @@ a:active {
     border: 2px solid rgba(49, 130, 246, 0.00);
 }
 
-#user-nickname{
+#user-nickname {
     display: flex;
     width: 640px;
     height: 56px;
@@ -215,11 +218,10 @@ a:active {
     border: 2px solid rgba(49, 130, 246, 0.00);
 }
 
-#user-pw-check{
+#user-pw-check {
     display: flex;
     width: 640px;
     height: 56px;
-    padding: 16px 24px;
     flex-direction: column;
     align-items: flex-start;
     gap: 10px;
@@ -228,11 +230,10 @@ a:active {
 }
 
 
-#user-pw{
+#user-pw {
     display: flex;
     width: 640px;
     height: 56px;
-    padding: 16px 24px;
     flex-direction: column;
     align-items: flex-start;
     gap: 10px;
@@ -240,30 +241,30 @@ a:active {
     background: var(--Cool-Gray-100, #F3F4F6);
 }
 
-#user-pw.login_eyes{
+#user-pw.login_eyes {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 16px;
     align-items: flex-start;
     align-self: stretch;
 }
 
-#user-pw-check
-.login_eyes_off{
+#user-pw-check .login_eyes_off .login_eyes {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 16px;
     align-items: flex-start;
     align-self: stretch;
 }
 
-.tit{
+.tit {
     text-align: center;
     color: var(--Secondary-800, #1F2937);
-/* pretendard/lg-16px-medium */
     font-family: Pretendard;
     font-size: 16px;
     font-style: normal;
     font-weight: 500;
-    line-height: 26px; /* 162.5% */
+    line-height: 26px;
 }
 
 .ipt-email,
@@ -276,14 +277,14 @@ a:active {
     gap: 16px;
 }
 
-.authForm{
+.authForm {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 24px;
 }
 
-.btns{
+.btns {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -295,40 +296,29 @@ a:active {
 .pw-check-box {
     display: flex;
     align-items: center;
-    width: 640px;
+    width: 645px;
     height: 56px;
-    padding: 0 16px;
     border-radius: 12px;
     background: #F3F4F6;
-    border: 1px solid #ccc;
-    box-sizing: border-box;
-}
-
-.input-common {
-    flex: 1; 
     border: none;
-    background: transparent;
-    font-size: 16px;
-    height: 100%;
-    outline: none;
-    padding-left: 16px;
+    box-sizing: border-box;
 }
 
 .icon-wrapper {
     flex-shrink: 0;
     width: 24px;
     height: 24px;
-    display: flex; 
+    display: flex;
     justify-content: center;
     align-items: center;
     cursor: pointer;
 }
 
-.icon-wrapper-check{
+.icon-wrapper-check {
     flex-shrink: 0;
     width: 24px;
     height: 24px;
-    display: flex; 
+    display: flex;
     justify-content: center;
     align-items: center;
     cursor: pointer;
@@ -336,21 +326,176 @@ a:active {
 
 
 .pw-check-bok {
-  position: relative;
-  width: 100%;
+    position: relative;
+    width: 100%;
 }
 
 .pw-check-bok input {
-  width: 100%;
-  padding-right: 40px;
-  box-sizing: border-box;
+    width: 100%;
+    padding-right: 24px;
+    box-sizing: border-box;
+}
+
+.area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    align-self: stretch;
+}
+
+.pw-box {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 640px;
+    height: 56px;
+    border-radius: 12px;
+    background: #F3F4F6;
+}
+
+.toggle-pw {
+    position: absolute;
+    right: 20px;
+    background: none;
+    width: 36px;
+    height: 36px;
+    border: none;
+    cursor: pointer;
+    font-size: 18px;
+}
+
+.login_eyes {
+    position: absolute;
+    left: 6px;
+    bottom: 6px;
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+.pw-check-box {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 640px;
+    height: 56px;
+    border-radius: 12px;
+    background: #F3F4F6;
+}
+
+.toggle-check-pw {
+    position: absolute;
+    right: 20px;
+    background: none;
+    width: 36px;
+    height: 36px;
+    border: none;
+    cursor: pointer;
+    font-size: 18px;
 }
 
 .login_eyes_off {
-  position: absolute;
-  right: 20px;
-  width: 24px;
-  height: 24px;
-  cursor: pointer;
-  bottom: 40px;
+    position: absolute;
+    left: 6px;
+    bottom: 6px;
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+@media screen and (min-width: 375px) and (max-width: 767px) {
+    .wrap {
+        padding: 24px 16px 16px 16px;
+        min-height: 100vh;
+    }
+
+    .formWrap {
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+        gap: 24px;
+    }
+
+    .panda_logo {
+        width: 100%;
+        max-width: 300px;
+        height: auto;
+        gap: 16px;
+    }
+
+    .panda_face {
+        width: 60px;
+        height: 60px;
+    }
+
+    .logo {
+        font-size: 40px;
+    }
+
+    .input-common,
+    #user-email,
+    #user-nickname,
+    #user-pw,
+    #user-pw-check {
+        width: 100%;
+        max-width: 400px;
+        box-sizing: border-box;
+    }
+
+    .pw-box,
+    .pw-check-box {
+        width: 100%;
+        max-width: 400px;
+        box-sizing: border-box;
+    }
+
+    .btn_lg {
+        width: 100%;
+        max-width: 400px;
+        padding: 16px 20px;
+        font-size: 18px;
+    }
+
+    .socialBtn-main {
+        width: 100%;
+        max-width: 400px;
+        padding: 16px;
+        box-sizing: border-box;
+    }
+
+    .socialBtn {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .authForm {
+        width: 100%;
+    }
+
+    .area {
+        width: 100%;
+        gap: 20px;
+    }
+
+    .ipt-email,
+    .ipt-nickname,
+    .ipt-pw,
+    .ipt-pw-check {
+        width: 100%;
+    }
+
+    .guideBtn {
+        text-align: center;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    label {
+        font-size: 14px;
+    }
+
+    .tit {
+        font-size: 14px;
+    }
 }

--- a/signup.html
+++ b/signup.html
@@ -22,45 +22,42 @@
                 </div>
             </div>
             <form class="authForm">
-                <div class="ipt-email">
-                    <label for="user-email">
-                        이메일
-                    </label>
-                    <input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
-                </div>
-                <div class="ipt-nickname">
-                    <label for="user-nickname">
-                        닉네임
-                    </label>
-                    <input id="user-nickname" type="nickname" class="input-common" placeholder="닉네임을 입력해 주세요.">
-                </div>
-                <div class="ipt-pw">
-                    <label for="user-pw">
-                        비밀번호
-                    </label>
-                    <div class="pw-box">
-                        <input id="user-pw" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
-                        <div class="icon-wrapper">
-                            <button type="button" aria-label="비밀번호 보이기">
+                <div class="area">
+                    <div class="ipt-email">
+                        <label for="user-email">
+                            이메일
+                        </label>
+                        <input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
+                    </div>
+                    <div class="ipt-nickname">
+                        <label for="user-nickname">
+                            닉네임
+                        </label>
+                        <input id="user-nickname" type="nickname" class="input-common" placeholder="닉네임을 입력해 주세요.">
+                    </div>
+                    <div class="ipt-pw">
+                        <label for="user-pw">
+                            비밀번호
+                        </label>
+                        <div class="pw-box">
+                            <input id="user-pw" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
+                            <button type="button" class="toggle-pw" aria-label="비밀번호 표시 전환">
                                 <img class="login_eyes" src="image/btn_visibility_on_24px.png" alt="로그인 눈모양">
                             </button>
                         </div>
                     </div>
-                </div>
-                <div class="ipt-pw-check">
-                    <label for="user-pw-check">
-                        비밀번호 확인
-                    </label>
-                    <div class="pw-check-bok">
-                        <input id="user-pw-check" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
-                        <div class="icon-wrapper-check">
-                            <button type="button" aria-label="비밀번호 보이기">
+                    <div class="ipt-pw-check">
+                        <label for="user-pw-check">
+                            비밀번호 확인
+                        </label>
+                        <div class="pw-check-box">
+                            <input id="user-pw-check" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
+                            <button type="button" class="toggle-check-pw" aria-label="비밀번호 보이기">
                                 <img class="login_eyes_off" src="image/btn_visibility_off_24px.png" alt="눈모양 오프">
                             </button>
                         </div>
                     </div>
-                </div>
-                <button type="button" class="btn_lg">회원가입</button>
+                    <button type="button" class="btn_lg">회원가입</button>
             </form>
             <div class="socialBtn-main">
                 <div class="socialBtn">
@@ -80,7 +77,8 @@
                 <span class="tit">이미 회원이신가요? </span>
                 <a href="/login" class="btnTxt">로그인</a>
             </div>
-        </main>
+    </div>
+    </main>
     </div>
 </body>
 

--- a/signup.html
+++ b/signup.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,70 +10,78 @@
 </head>
 
 <body>
-        <div class="wrap">
-            <main class="formWrap">
-                <div class="formHeader">
+    <div class="wrap">
+        <main class="formWrap">
+            <div class="formHeader">
                 <div class="panda_logo">
-                <span class="logo"><a href="/">
-                    <span class="blind">
-                        판다마켓
-                    </span></a></span>
-                <img class="panda_face" src="image/panda_face.png" alt="로그인-판다머리아이콘">
+                    <span class="logo"><a href="/">
+                            <span class="blind">
+                                판다마켓
+                            </span></a></span>
+                    <img class="panda_face" src="image/panda_face.png" alt="로그인-판다머리아이콘">
                 </div>
             </div>
-                <form class="authForm">
-                    <div class="ipt-email">
-                        <label for="user-email">
-                            이메일
-                        </label>
-                        <input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
-                    </div>
-                    <div class="ipt-nickname">
-                        <label for="user-nickname">
-                            닉네임
-                        </label>
-                        <input id="user-nickname" type="nickname" class="input-common" placeholder="닉네임을 입력해 주세요.">
-                    </div>
-                    <div class="ipt-pw">
-                        <label for="user-pw">
-                            비밀번호
-                        </label>
-                        <div class="pw-box">
+            <form class="authForm">
+                <div class="ipt-email">
+                    <label for="user-email">
+                        이메일
+                    </label>
+                    <input id="user-email" type="email" class="input-common" placeholder="이메일을 입력해 주세요.">
+                </div>
+                <div class="ipt-nickname">
+                    <label for="user-nickname">
+                        닉네임
+                    </label>
+                    <input id="user-nickname" type="nickname" class="input-common" placeholder="닉네임을 입력해 주세요.">
+                </div>
+                <div class="ipt-pw">
+                    <label for="user-pw">
+                        비밀번호
+                    </label>
+                    <div class="pw-box">
                         <input id="user-pw" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
                         <div class="icon-wrapper">
-                        <img class="login_eyes" src="image/btn_visibility_on_24px.png" alt="로그인 눈모양"> 
+                            <button type="button" aria-label="비밀번호 보이기">
+                                <img class="login_eyes" src="image/btn_visibility_on_24px.png" alt="로그인 눈모양">
+                            </button>
+                        </div>
                     </div>
-                    </div>
-                    </div>
-                    <div class="ipt-pw-check">
-                        <label for="user-pw-check">
-                            비밀번호 확인
-                        </label>
-                        <div class="pw-check-bok">
+                </div>
+                <div class="ipt-pw-check">
+                    <label for="user-pw-check">
+                        비밀번호 확인
+                    </label>
+                    <div class="pw-check-bok">
                         <input id="user-pw-check" type="password" class="input-common" placeholder="비밀번호를 입력해 주세요.">
                         <div class="icon-wrapper-check">
-                        <img class="login_eyes_off" src="image/btn_visibility_off_24px.png" alt="눈모양 오프">
+                            <button type="button" aria-label="비밀번호 보이기">
+                                <img class="login_eyes_off" src="image/btn_visibility_off_24px.png" alt="눈모양 오프">
+                            </button>
                         </div>
-                    </div> 
                     </div>
-                            <button type="button" class="btn_lg">회원가입</button>
-                </form>
+                </div>
+                <button type="button" class="btn_lg">회원가입</button>
+            </form>
             <div class="socialBtn-main">
                 <div class="socialBtn">
                     <span class="tit">
                         간편 로그인하기
                     </span>
                     <div class="btns">
-                        <a class="socialBtn-box-google" href="https://www.google.com/" target="_blank" rel="noopener noreferrer" title="새창으로 열기"><img src="image/google_icon.png" alt="구글 로그인"></a>
-                        <a class="socialBtn-box-kakao"  href="https://www.kakaocorp.com/page/" target="_blank" rel="noopener noreferrer" title="새창으로 열기"><img src="image/kakao_icon.png" alt="카카오톡 로그인"></a>
+                        <a class="socialBtn-box-google" href="https://www.google.com/" target="_blank"
+                            rel="noopener noreferrer" title="새창으로 열기"><img src="image/google_icon.png" alt="구글 로그인"></a>
+                        <a class="socialBtn-box-kakao" href="https://www.kakaocorp.com/page/" target="_blank"
+                            rel="noopener noreferrer" title="새창으로 열기"><img src="image/kakao_icon.png"
+                                alt="카카오톡 로그인"></a>
                     </div>
                 </div>
             </div>
-                <div class="guideBtn">
-                    <span class="tit">이미 회원이신가요? </span>
-                    <a href="/login" class="btnTxt">로그인</a>
-                </div>
-            </main>
-        </div>
-    </body>
+            <div class="guideBtn">
+                <span class="tit">이미 회원이신가요? </span>
+                <a href="/login" class="btnTxt">로그인</a>
+            </div>
+        </main>
+    </div>
+</body>
+
 </html>

--- a/style.css
+++ b/style.css
@@ -47,8 +47,25 @@ header {
 }
 
 #header-logo img {
-    height: 32px;
-    width: auto;
+    width: 40px;
+    height: 40.135px;
+    flex-shrink: 0;
+}
+
+.header-tit {
+    text-decoration: none;
+    color: #3692FF;
+    font-family: "ROKAF Sans";
+    font-size: 25.633px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+}
+
+#header-logo,
+#header-logo:visited {
+    text-decoration: none;
+    color: #3692FF;
 }
 
 .login-button {
@@ -127,6 +144,12 @@ main {
     align-items: center;
 }
 
+.pos-bottom-left {
+    position: absolute;
+    bottom: 20%;
+    left: 13%;
+}
+
 .home-image img {
     width: 100%;
     height: 100%;
@@ -173,7 +196,7 @@ main {
     max-width: 400px;
 }
 
-#second-content {
+.text-right {
     text-align: right;
 }
 

--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ main {
     align-items: flex-end;
 }
 
-.home-box{
+.home-box {
     display: inline-flex;
     align-items: center;
     gap: 7px;
@@ -114,7 +114,8 @@ main {
     font-size: 20px;
     font-style: normal;
     font-weight: 600;
-    line-height: 32px; /* 160% */
+    line-height: 32px;
+    /* 160% */
 }
 
 .home-image {
@@ -183,7 +184,8 @@ main {
     font-size: 18px;
     font-style: normal;
     font-weight: 800;
-    line-height: 26px; /* 144.444% */
+    line-height: 26px;
+    /* 144.444% */
 }
 
 .content-title {
@@ -192,7 +194,8 @@ main {
     font-size: 40px;
     font-style: normal;
     font-weight: 700;
-    line-height: 140%; /* 56px */
+    line-height: 140%;
+    /* 56px */
     letter-spacing: 0.8px;
 }
 
@@ -203,20 +206,21 @@ main {
     font-size: 24px;
     font-style: normal;
     font-weight: 500;
-    line-height: 32px; /* 133.333% */
+    line-height: 32px;
+    /* 133.333% */
 }
 
 .footer-main {
     width: 100%;
     height: 540px;
     background-color: #CFE5FF;
-    display: flex; 
+    display: flex;
     justify-content: center;
     align-items: flex-end;
-    gap: 69px; 
+    gap: 69px;
 }
 
-.footer-main-box{
+.footer-main-box {
     display: inline-flex;
     align-items: center;
     gap: 69px;
@@ -228,7 +232,8 @@ main {
     font-size: 40px;
     font-style: normal;
     font-weight: 700;
-    line-height: 140%; /* 56px */
+    line-height: 140%;
+    /* 56px */
 }
 
 .footer-image {
@@ -247,7 +252,7 @@ main {
     border-radius: 20px;
 }
 
-.footer-bottom{
+.footer-bottom {
     display: flex;
     width: 1920px;
     height: 160px;
@@ -269,7 +274,7 @@ main {
 
 
 
-.footer-ppf{
+.footer-ppf {
     color: var(--Secondary-200, #E5E7EB);
     text-align: center;
     font-family: Pretendard;
@@ -283,12 +288,12 @@ main {
 }
 
 
-.footer-ppf > a {
+.footer-ppf>a {
     text-decoration: none;
     color: #9CA3AF;
 }
 
-.footer-ppf > a:hover {
+.footer-ppf>a:hover {
     color: #D1D5DB;
 }
 
@@ -299,7 +304,7 @@ main {
     gap: 12px;
 }
 
-.footer-codeit{
+.footer-codeit {
     color: var(--Secondary-400, #9CA3AF);
     text-align: center;
     font-family: Pretendard;

--- a/style.css
+++ b/style.css
@@ -9,9 +9,8 @@ body {
 
 header {
     display: flex;
-    width: 1920px;
     height: 70px;
-    padding: 9px 400px;
+    padding: 0;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -27,18 +26,17 @@ header {
 }
 
 .header-box {
-    width: 1120px;
-    height: 51px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin: 0 200px;
-    padding: 10px 20px;
+    width: 100%;
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 0 16px;
 }
 
 #header-logo {
     display: flex;
-    width: 153px;
     height: 51px;
     padding: 5.017px 0 5.848px 0;
     justify-content: center;
@@ -126,13 +124,11 @@ main {
     text-decoration: none;
     color: var(--Secondary-50, #F9FAFB);
     text-align: center;
-    /* pretendard/xl-20px-semibold */
     font-family: Pretendard;
     font-size: 20px;
     font-style: normal;
     font-weight: 600;
     line-height: 32px;
-    /* 160% */
 }
 
 .home-image {
@@ -153,12 +149,10 @@ main {
 .home-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
 }
 
 .content {
     display: flex;
-    width: 1920px;
     padding: 138px 0;
     flex-direction: column;
     justify-content: center;
@@ -196,19 +190,24 @@ main {
     max-width: 400px;
 }
 
+.content-text-box-text {
+    display: flex;
+    flex-direction: column;
+    max-width: 400px;
+}
+
 .text-right {
+
     text-align: right;
 }
 
 .content-header {
     color: var(--Primary-100, #3692FF);
-    /* pretendard/2lg-18px-bold */
     font-family: "Abhaya Libre ExtraBold";
     font-size: 18px;
     font-style: normal;
     font-weight: 800;
     line-height: 26px;
-    /* 144.444% */
 }
 
 .content-title {
@@ -218,19 +217,16 @@ main {
     font-style: normal;
     font-weight: 700;
     line-height: 140%;
-    /* 56px */
     letter-spacing: 0.8px;
 }
 
 .content-info {
     color: var(--Secondary-700, #374151);
-    /* pretendard/2xl-24px-medium */
     font-family: Pretendard;
     font-size: 24px;
     font-style: normal;
     font-weight: 500;
     line-height: 32px;
-    /* 133.333% */
 }
 
 .footer-main {
@@ -256,7 +252,6 @@ main {
     font-style: normal;
     font-weight: 700;
     line-height: 140%;
-    /* 56px */
 }
 
 .footer-image {
@@ -277,7 +272,6 @@ main {
 
 .footer-bottom {
     display: flex;
-    width: 1920px;
     height: 160px;
     padding: 32px 400px;
     flex-direction: column;
@@ -288,7 +282,6 @@ main {
 }
 
 .footer-bottom-box {
-    width: 1120px;
     color: #9CA3AF;
     display: flex;
     justify-content: space-between;
@@ -354,4 +347,660 @@ main {
 
 body a {
     cursor: pointer;
+}
+
+.header-box,
+.footer-bottom-box {
+    width: 100%;
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 0 24px;
+    box-sizing: border-box;
+}
+
+.mobile-br::after {
+    content: "\A";
+    white-space: pre;
+}
+
+
+
+
+/* ----------------------
+   Mobile (375px ~ 767px)
+----------------------- */
+@media screen and (min-width: 375px) and (max-width: 767px) {
+
+    .header-box {
+        width: 100%;
+        padding: 0 16px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin: 0;
+    }
+
+    .footer-bottom {
+
+        background: #111827;
+        padding: 24px 16px;
+    }
+
+    .footer-bottom {
+        background: #111827;
+        padding: 24px 16px;
+    }
+
+    .footer-bottom-box {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 20px;
+    }
+
+    .footer-ppf {
+        display: flex;
+        gap: 20px;
+    }
+
+    .footer-ppf a {
+        text-decoration: none;
+        color: #9CA3AF;
+        font-size: 14px;
+    }
+
+    .footer-ppf a:hover {
+        color: #fff;
+    }
+
+    .footer-sns {
+        display: flex;
+        gap: 12px;
+    }
+
+    .footer-sns img {
+        width: 20px;
+        height: 20px;
+    }
+
+    .footer-codeit {
+        font-size: 14px;
+        color: #9CA3AF;
+        text-align: center;
+    }
+
+    #header-logo img {
+        display: none;
+    }
+
+    .content-title br {
+        display: none;
+    }
+
+    a.footer-codeit,
+    a.footer-ppf {
+        white-space: nowrap;
+    }
+
+    .home-image {
+        height: auto;
+        margin-left: calc(50% - 50vw);
+    }
+
+    .home-image img {
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+    }
+
+    .footer-text {
+        text-align: center;
+        width: 100%;
+    }
+
+    .footer-image {
+        width: 100vw;
+        height: auto;
+        margin-left: calc(50% - 50vw);
+        max-width: none;
+    }
+
+    .footer-image img {
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+    }
+
+    .footer-bottom {
+        background: #111827;
+        padding: 24px 16px;
+    }
+
+    .footer-bottom-box {
+        max-width: 1120px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .footer-ppf {
+        display: flex;
+        gap: 20px;
+    }
+
+    .footer-ppf a {
+        text-decoration: none;
+        color: #9CA3AF;
+        font-size: 14px;
+    }
+
+    .footer-ppf a:hover {
+        color: #fff;
+    }
+
+    .footer-sns {
+        display: flex;
+        gap: 12px;
+    }
+
+    .footer-sns img {
+        width: 20px;
+        height: 20px;
+    }
+
+    .footer-codeit {
+        font-size: 14px;
+        color: #9CA3AF;
+        text-align: left;
+    }
+
+    .home-image {
+        width: 100vw;
+        height: auto;
+        margin-left: calc(50% - 50vw);
+    }
+
+    .home-image img {
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+
+    }
+
+    .formWrap,
+    .authForm,
+    .input-common,
+    #user-email,
+    #user-pw,
+    #user-nickname,
+    #user-pw-check,
+    .pw-box,
+    .pw-check-box,
+    .btn_lg,
+    .socialBtn {
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+    }
+
+
+    .header-box {
+        width: 100%;
+        padding: 0 16px;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    #header-logo img {
+        display: none;
+    }
+
+    .header-tit {
+        font-size: 20px;
+        font-weight: 700;
+    }
+
+    main {
+        padding-top: 70px;
+        margin-bottom: 60px;
+    }
+
+    .home {
+        height: auto;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+
+    .home-box {
+        flex-direction: column;
+        gap: 24px;
+        width: 100%;
+    }
+
+    .home-text-box {
+        gap: 20px;
+        align-items: center;
+    }
+
+    #home-text {
+        font-size: 28px;
+        line-height: 1.4;
+    }
+
+    #go-look-button {
+        width: 100%;
+        max-width: 280px;
+        padding: 12px 0;
+        font-size: 16px;
+    }
+
+    .home-image {
+        width: 100%;
+        height: auto;
+    }
+
+    .home-image img {
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+    }
+
+    .content {
+        padding: 40px 16px;
+    }
+
+    .content-box {
+        flex-direction: column;
+        gap: 20px;
+        width: 100%;
+    }
+
+    .content-image {
+        width: 100%;
+        height: auto;
+    }
+
+    .content-text-box {
+        width: 100%;
+    }
+
+    .content-title {
+        font-size: 24px;
+        line-height: 1.4;
+    }
+
+    .content-info {
+        font-size: 16px;
+        line-height: 1.4;
+    }
+
+    .footer-main {
+        height: auto;
+        text-align: center;
+    }
+
+    .footer-main-box {
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .footer-text {
+        font-size: 20px;
+        line-height: 1.4;
+    }
+
+    .footer-image {
+        width: 100%;
+        max-width: 260px;
+        margin: 0 auto;
+    }
+
+    .home-image {
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100vw;
+        max-width: none;
+        margin: 0;
+        padding: 0;
+        height: auto;
+    }
+
+    .home-image img {
+        display: block;
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+        border-radius: 0;
+    }
+
+    .footer-text {
+        text-align: center;
+        width: 100%;
+    }
+
+    .footer-image {
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100vw;
+        max-width: none;
+        margin: 0;
+        padding: 0;
+        height: auto;
+    }
+
+    .footer-image img {
+        display: block;
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+        border-radius: 0;
+    }
+
+    .footer-top {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+    }
+
+    .footer-bottom {
+        background: #111827;
+        padding: 24px 16px;
+    }
+
+    .footer-bottom-box {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        grid-template-rows: auto auto;
+        gap: 20px 0;
+        width: 100%;
+        max-width: 1120px;
+        margin: 0 auto;
+        align-items: center;
+    }
+
+
+    .footer-top {
+        grid-column: 1;
+        grid-row: 1;
+    }
+
+
+    .footer-sns {
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+
+    .footer-codeit {
+        grid-column: 1;
+        grid-row: 2;
+    }
+
+    .footer-ppf {
+        display: flex;
+        gap: 30px;
+    }
+
+    .footer-ppf a {
+        font-size: 14px;
+        color: #9CA3AF;
+        text-decoration: none;
+    }
+
+    .footer-ppf a:hover {
+        color: #fff;
+    }
+
+    .footer-sns {
+        display: flex;
+        gap: 12px;
+    }
+
+    .footer-sns img {
+        width: 20px;
+        height: 20px;
+    }
+
+    .footer-codeit {
+        font-size: 14px;
+        color: #9CA3AF;
+        text-align: left;
+        width: 100%;
+    }
+}
+
+
+
+
+
+
+
+/* ----------------------
+   Tablet (768px ~ 1199px)
+----------------------- */
+@media screen and (min-width: 768px) and (max-width: 1199px) {
+    .header-box {
+        padding: 0 24px;
+    }
+
+    .content-title {
+        font-size: 28px;
+    }
+
+    .content-image.search-image {
+        order: -1;
+    }
+
+    .footer-image img {
+        width: auto;
+    }
+
+    .content-image.hot-item-image.img {
+        width: 100vw;
+        height: auto;
+        object-fit: cover;
+        margin-left: calc(50% - 50vw);
+    }
+
+    .content-image {
+        width: 100%;
+        height: auto;
+    }
+
+    .content {
+        padding: 24px 0 0 0;
+        gap: 24px;
+    }
+
+    .content-box {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 24px;
+        width: 100%;
+        max-width: 988px;
+        margin: 0 auto;
+        padding: 0 16px;
+    }
+
+    .formWrap,
+    .authForm {
+        width: 640px;
+        margin: 0 auto;
+        max-width: none;
+    }
+
+    #home-text {
+        white-space: normal;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+    }
+
+    .mobile-br::after {
+        content: " ";
+    }
+
+    .home-box {
+        display: block;
+    }
+
+    .content-box {
+        width: 100%;
+        padding: 0 16px;
+        max-width: 988px;
+        margin: 0 auto;
+    }
+
+    .home-image,
+    .footer-image {
+        width: 100%;
+        max-width: 350px;
+    }
+
+    .home-box {
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .home-image {
+        width: 100vw;
+        height: 300px;
+    }
+
+    .home-image img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .home {
+        padding: 0;
+    }
+
+    .home-box {
+        width: 100%;
+        padding: 0 16px;
+        box-sizing: border-box;
+    }
+
+    .home-image {
+        width: 100%;
+        height: auto;
+        max-width: none;
+    }
+
+    .home {
+        width: 100%;
+        margin: 0;
+        padding: 0;
+    }
+
+    .home-box {
+        width: 100%;
+        justify-content: center;
+        padding: 0;
+    }
+
+    .footer-main-box {
+        display: block;
+    }
+
+    .content-box {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 24px;
+        width: 100%;
+        max-width: 988px;
+        margin: 0 auto;
+        align-self: stretch;
+    }
+
+    .content-text-box {
+        max-width: 400px;
+        width: 100%;
+    }
+
+    .home-text-box {
+        gap: 24px;
+    }
+
+    .content-text-box.text-right {
+        align-items: flex-end;
+        margin-top: 20px;
+        width: 100%;
+        max-width: 988px;
+    }
+
+    main {
+        margin-bottom: 100px;
+        padding-top: 70px;
+    }
+
+    #go-look-button {
+        padding: 16px 40px;
+    }
+
+    h2 br {
+        display: none;
+    }
+
+    .footer-text {
+        text-align: center;
+    }
+
+
+    .footer-bottom {
+        background: #111827;
+        padding: 24px 16px;
+    }
+
+    .footer-bottom-box {
+        max-width: 1120px;
+        margin: 0 auto;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 16px;
+        flex-wrap: nowrap;
+    }
+
+    .footer-left {
+        display: flex;
+        align-items: center;
+        gap: 30px;
+    }
+
+    .footer-codeit {
+        font-size: 14px;
+        color: #9CA3AF;
+    }
+
+    .footer-ppf a {
+        text-decoration: none;
+        color: #9CA3AF;
+        font-size: 14px;
+    }
+
+    .footer-ppf a:hover {
+        color: #fff;
+    }
+
+    .footer-sns {
+        display: flex;
+        gap: 12px;
+    }
+
+    .footer-sns img {
+        width: 20px;
+        height: 20px;
+    }
+
 }


### PR DESCRIPTION
## 요구사항
### 배포링크
https://capable-concha-4462b3.netlify.app/
### 기본

- [x] Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- [x] 피그마 디자인에 맞게 페이지를 만들어 주세요.
- [x] React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.


### 공통
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하 * 375px 미만 사이즈의 디자인은 고려하지 않습니다.

### 메인 페이지
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
 - [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
 - [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.
### 로그인, 회원가입 페이지
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x]  Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.


### 심화

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x]  미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [x]  주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

- 스프린트미션2 보완
- 스프린트미션3 구현완료

## 스크린샷
<img width="269" height="235" alt="메타태그" src="https://github.com/user-attachments/assets/90451fc3-3954-4d78-b743-f231b105f57e" />



## 주강사님에게

- 시간이 좀 많이 걸렸지만 구현을 할수 있도록 노력하였습니다.
- 만약 필요한 문법이나 코드가 생각이 안날때 인터넷을 찾아보는 방법밖에 없을까요?
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.