### PR TITLE
[방다연] sprint4

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -6,6 +6,7 @@
     <title>Login</title>
     <link rel="stylesheet" href="../styles/globals.css">
     <link rel="stylesheet" href="../styles/auth.css">
+    <script type="module" src="../scripts/auth.js" defer></script>
 </head>
 <body>
     <div class="auth-container">
@@ -17,23 +18,25 @@
                 <div class="input-container">
                     <label for="email">이메일</label>
                     <input type="email" id="email" name="email" placeholder="이메일을 입력하세요" required>
+                    <div class="error-message" id="email-error"></div>
                 </div>
                 <div class="input-container">
                     <label for="password">비밀번호</label>
                     <div class="password-input-container">
                         <input type="password" id="password" name="password" placeholder="비밀번호를 입력하세요" required>
-                        <img class="icon-button visibility" src="../images/ic_visibility_off.png" alt="비밀번호 표시 아이콘">
+                        <img id="toggle-password" class="icon-button visibility" src="../images/ic_visibility_off.png" alt="비밀번호 표시 아이콘">
                     </div>
+                    <div class="error-message" id="password-error"></div>
                 </div>
-                <button type="submit" class="button submit">로그인</button>
+                <button id="submit-btn" type="submit" class="button submit" disabled>로그인</button>
             </form>
             <div class="easy-login">
                 <span>간편 로그인하기</span>
                 <div class="social-icon-container">
-                    <a href="https://www.google.com/" _target="_blank">
+                    <a href="https://www.google.com/" target="_blank">
                         <img class="google" src="../images/ic_google.png" alt="구글 로그인 아이콘">
                     </a>
-                    <a href="https://www.kakaocorp.com/" _target="_blank">
+                    <a href="https://www.kakaocorp.com/" target="_blank">
                         <img class="kakao" src="../images/ic_kakao.png" alt="카카오 로그인 아이콘">
                     </a>
                 </div>

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,0 +1,144 @@
+// 메세지 상수
+const Msg = Object.freeze({
+    email: {
+        required: "이메일을 입력해주세요.",
+        invalid: "잘못된 이메일 형식입니다."
+    },
+    nickname: {
+        required: "닉네임을 입력해주세요."
+    },
+    password: {
+        required: "비밀번호를 입력해주세요.",
+        invalid: "비밀번호를 8자 이상 입력해주세요."
+    },
+    confirm: {
+        invalid: "비밀번호가 일치하지 않습니다."
+    }
+});
+
+// 아이콘 상수
+const Icons = {
+    visible: "../images/ic_visibility_on.png",
+    invisible: "../images/ic_visibility_off.png"
+};
+
+// 공통 유틸
+function showError(field, msg) {
+    field.error.textContent = msg;
+    field.input.classList.add("error");
+    return false;
+}
+
+function clearError(field) {
+    field.error.textContent = "";
+    field.input.classList.remove("error");
+    return true;
+}
+
+// 필드 정의
+const fields = {
+    email: {
+        input: document.getElementById("email"),
+        error: document.getElementById("email-error"),
+    },
+    nickname: document.getElementById("nickname") ? { 
+        input: document.getElementById("nickname"),
+        error: document.getElementById("nickname-error")
+    }: null,
+    password: {
+        input: document.getElementById("password"),
+        error: document.getElementById("password-error"),
+        toggle: document.getElementById("toggle-password")
+    },
+    confirm: document.getElementById("confirm-password") ? {
+        input: document.getElementById("confirm-password"),
+        error: document.getElementById("confirm-password-error"),
+        toggle: document.getElementById("toggle-confirm")
+    }: null
+}
+
+const { email, nickname, password, confirm } = fields;
+const submitBtn = document.getElementById("submit-btn");
+
+// 유효성 검증 함수
+function validateField(field, checks = []) {
+    if(!field) return true;
+
+    const v = field.input.value.trim();
+    for(let check of checks) {
+        if(check(v))
+            return showError(field, check(v));
+    }
+    return clearError(field);
+}
+
+const validateEmail = () => // validateField의 공통 로직을 사용하며 email관련 인자를 전달하는 화살표함수
+    validateField(email, [
+        v => !v ? Msg.email.required : null,
+        v => !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) ? Msg.email.invalid : null
+    ]);
+
+const validateNickname = () => 
+    validateField(nickname, [
+        v => !v ? Msg.nickname.required : null
+    ]);
+
+const validatePassword = () => 
+    validateField(password, [
+        v => !v ? Msg.password.required : null,
+        v => v.length < 8 ? Msg.password.invalid : null
+    ]);
+
+const validateConfirm = () => 
+    validateField(confirm, [
+        v => password.input.value.trim() !== v ? Msg.confirm.invalid : null
+    ]);
+
+
+// 로그인 버튼 활성화
+function toggleSubmitButton() {
+    if(validateEmail() && validateNickname() && validatePassword() && validateConfirm()) {
+        submitBtn.disabled = false;
+        submitBtn.classList.add("enabled");
+    } else {
+        submitBtn.disabled = true;
+        submitBtn.classList.remove("enabled");
+    }
+}
+
+// 이벤트 등록
+function addFieldEvents(field, validator) {
+    if(!field) return;
+
+    field.input.addEventListener("input", toggleSubmitButton());
+    field.input.addEventListener("focusout", () => {
+        validator();
+        toggleSubmitButton();
+    });
+}
+addFieldEvents(email, validateEmail);
+addFieldEvents(nickname, validateNickname);
+addFieldEvents(password, validatePassword);
+addFieldEvents(confirm, validateConfirm);
+
+// visible 토글
+function setVisibleToggle(toggleId, field) {
+    if(!toggleId || !field) return;
+
+    toggleId.addEventListener("click", () => {
+        field.input.type = field.input.type === "password" ? "text" : "password";
+        toggleId.src = field.input.type === "password" ? Icons.invisible : Icons.visible;
+    });
+}
+setVisibleToggle(password.toggle, password);
+if(confirm) setVisibleToggle(confirm.toggle, confirm);
+
+
+// 로그인/회원가입 버튼
+submitBtn.addEventListener("click", (e)=> {
+    e.preventDefault(); // form 제출 정지
+    if(submitBtn.disabled) return;
+
+    window.location.href = window.location.pathname.includes("/login") ? "/items" : "/login";
+    
+});

--- a/signup/index.html
+++ b/signup/index.html
@@ -6,6 +6,7 @@
     <title>회원가입 페이지</title>
     <link rel="stylesheet" href="../styles/globals.css">
     <link rel="stylesheet" href="../styles/auth.css">
+    <script type="module" src="../scripts/auth.js" defer></script>
 </head>
 <body>
     <div class="auth-container">
@@ -13,30 +14,34 @@
             <img class="logo" src="../images/logo.png" alt="logo and link to home page">
         </a>
         <div class="auths">
-            <form class="form-container" action="#" method="post">
+            <form id="authForm" class="form-container" action="#" method="post">
                 <div class="input-container">
                     <label for="email">이메일</label>
                     <input type="email" id="email" name="email" placeholder="이메일을 입력하세요" required>
+                    <div class="error-message" id="email-error"></div>
                 </div>
                 <div class="input-container">
                     <label for="nickname">닉네임</label>
                     <input type="text" id="nickname" name="nickname" placeholder="닉네임을 입력하세요" required>
+                    <div class="error-message" id="nickname-error"></div>
                 </div>
                 <div class="input-container">
                     <label for="password">비밀번호</label>
                     <div class="password-input-container">
                         <input type="password" id="password" name="password" placeholder="비밀번호를 입력하세요" required>
-                        <img class="icon-button visibility" src="../images/ic_visibility_off.png" alt="숨김 아이콘">
+                        <img id="toggle-password" class="icon-button visibility" src="../images/ic_visibility_off.png" alt="숨김 아이콘">
                     </div>
+                    <div class="error-message" id="password-error"></div>
                 </div>
                 <div class="input-container">
                     <label for="confirm-password">비밀번호 확인</label>
                     <div class="password-input-container">
                         <input type="password" id="confirm-password" name="confirm-password" placeholder="비밀번호를 다시 입력하세요" required>
-                        <img class="icon-button visibility" src="../images/ic_visibility_off.png" alt="숨김 아이콘">
+                        <img id="toggle-confirm" class="icon-button visibility" src="../images/ic_visibility_off.png" alt="숨김 아이콘">
                     </div>
+                    <div class="error-message" id="confirm-password-error"></div>
                 </div>
-                <button type="submit" class="button submit">회원가입</button>
+                <button id="submit-btn" type="submit" class="button submit">회원가입</button>
             </form>
             <div class="easy-login">
                 <span>간편 로그인하기</span>

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -56,6 +56,16 @@ input {
     border: 2px solid var(--blue);
 }
 
+input.error {
+    border: 2px solid var(--red);
+}
+
+.error-message {
+    color: var(--red);
+    margin-left: 16px;
+    font-size: 14px;
+}
+
 .password-input-container {
     position: relative;
     width: 100%;
@@ -75,7 +85,7 @@ input {
     background-color: var(--gray400);
     border-radius: 40px;
     pointer-events: none;
-}form:valid .button.submit {
+} .button.submit.enabled {
     pointer-events: auto;
     background-color: var(--blue);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 :root {
+    --red: #F74747;
     --blue: #3692FF;
     --light-blue: #CFE5FF;
     --gray900: #111827;


### PR DESCRIPTION
# 결과
[Netlify](https://bdy-sprint-mission-1.netlify.app/)
# 체크리스트 [기본]
**로그인**
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "이메일을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 "잘못된 이메일 형식입니다" 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 "비밀번호를 입력해주세요." 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 "비밀번호를 8자 이상 입력해주세요." 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 '로그인' 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 '로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 '로그인' 버튼을 누르면 "/items" 로 이동합니다.

**회원가입**
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "이메일을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 "잘못된 이메일 형식입니다" 빨강색 에러 메세지를 보입니다.
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "닉네임을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 "비밀번호를 입력해주세요." 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 "비밀번호를 8자 이상 입력해주세요." 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 "비밀번호가 일치하지 않습니다.." 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 '회원가입' 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 '회원가입' 버튼이 활성화 됩니다.
- [x] 활성화된 '회원가입' 버튼을 누르면 로그인 페이지로 이동합니다

# 체크리스트 [심화]
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

# 질문 사항
- 이메일 input에서 **자동완성**으로 이메일을 입력하면 `input background color`가 파란색으로 바뀌고, `focusout`해도 여전히 파란색인데 이부분도 css에서 스타일링 할 수 있는 걸까요?
- 입력을 진행하는 동안(`focus 상태`)은 이메일/비밀번호 형식을 만족하지 않는 상태이지만, focus 스타일을 따로 지정하지 않아 빨간색 테두리가 아닙니다. 보통의 경우 입력 중일 때도 `error 스타일링`을 하는지, 아니면 `focus 스타일`이 우선시 되는지 궁금합니다.
- `auth.js`라는 파일에 로그인과 회원가입의 기능을 전부 작성하고, 내부에서 if문으로 각 페이지에 따른 기능을 구분했는데 이런 방식은 같은 기능을 공유하는 파일이 많아진다면 유지보수가 어려울 것 같습니다. 구조를 어떻게 수정하면 좋을지 궁금합니다.